### PR TITLE
Reduce-Combine

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-detector",
-  "version": "0.5.3",
+  "version": "0.6.0-0",
   "description": "Redux enhancer for pure detection of state changes.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/ActionLike.ts
+++ b/src/ActionLike.ts
@@ -1,5 +1,8 @@
 import { Action } from 'redux';
 
+/**
+ * Interface that requires `type: string` field and is open for every extension.
+ */
 export interface ActionLike extends Action {
   [key: string]: any;
 }

--- a/src/DetectableStore.ts
+++ b/src/DetectableStore.ts
@@ -1,6 +1,9 @@
 import { Store } from 'redux';
 import { Detector } from './Detector';
 
+/**
+ * Store enhanced by detector enhancer.
+ */
 export interface DetectableStore<S> extends Store<S> {
   replaceDetector(nextDetector: Detector<S>): void;
 }

--- a/src/Detector.ts
+++ b/src/Detector.ts
@@ -1,5 +1,9 @@
 import { ActionLike } from './ActionLike';
 
-// we use ActionLike instead of <A extends Action>, because second form doesn't check type on definition, only on call expression.
-// we could use also Detector<S, A>, but it's not practical - all we need to know is that ActionLike object has 'type': string field.
+/**
+ * Function that compares previous and next state and can returns action, array of actions or undefined.
+ *
+ * There is ActionLike instead of <A extends Action>, because second form doesn't check type on definition, only on call expression.
+ * We could use also Detector<S, A>, but it's not practical - all we need to know is that ActionLike object has 'type': string field.
+ */
 export type Detector<S> = (prevState: S | undefined, nextState: S) => ActionLike | ActionLike[] | void;

--- a/src/DetectorsMap.ts
+++ b/src/DetectorsMap.ts
@@ -1,0 +1,5 @@
+import { Detector } from './Detector';
+
+export type DetectorsMap<S> = {
+  [K in keyof S]?: Detector<S[K]>;
+};

--- a/src/combineDetectors.ts
+++ b/src/combineDetectors.ts
@@ -1,0 +1,34 @@
+import { Detector } from './Detector';
+import { ActionLike } from './ActionLike';
+import { DetectorsMap } from './DetectorsMap';
+
+/**
+ * Combine detectors to bind them to the local state.
+ * It allows to create reusable detectors.
+ *
+ * @param map Map of detectors bounded to state.
+ * @returns Combined detector
+ */
+export function combineDetectors<S>(map: DetectorsMap<S>): Detector<S> {
+  return function combinedDetector(prevState: S | undefined, nextState: S): ActionLike[] {
+    return Object.keys(map).reduce(
+      (reducedActions: ActionLike[], key: keyof S) => {
+        let actions: ActionLike | ActionLike[] | void = map[key]!(
+          prevState ? prevState[key] : undefined,
+          nextState[key]
+        );
+
+        if (actions) {
+          if (actions.constructor !== Array) {
+            actions = [actions as ActionLike];
+          }
+
+          reducedActions = reducedActions.concat(...(actions as ActionLike[]));
+        }
+
+        return reducedActions;
+      },
+      []
+    );
+  };
+}

--- a/src/createDetectableStore.ts
+++ b/src/createDetectableStore.ts
@@ -3,6 +3,15 @@ import { Detector } from './Detector';
 import { DetectableStore } from './DetectableStore';
 import { createDetectorEnhancer } from './createDetectorEnhancer';
 
+/**
+ * Creates store with enhanced by detector enhancer (`createDetectorEnhancer`)
+ *
+ * @param reducer Root reducer
+ * @param detector Root detector
+ * @param preloadedState Preloaded state for store
+ * @param enhancer Custom enhancer (it will be composed with detector enhancer)
+ * @returns Detectable store
+ */
 export function createDetectableStore<S>(
   reducer: Reducer<S>,
   detector: Detector<S>,

--- a/src/createDetectorEnhancer.ts
+++ b/src/createDetectorEnhancer.ts
@@ -10,6 +10,12 @@ export const ActionTypes: { INIT: string } = {
 export type StoreDetectableEnhancer<S> = (next: StoreEnhancerStoreCreator<S>) => StoreEnhancerStoreDetectableCreator<S>;
 export type StoreEnhancerStoreDetectableCreator<S> = (reducer: Reducer<S>, preloadedState: S) => DetectableStore<S>;
 
+/**
+ * Creates detector enhancer that modifies redux store to use it with provided detector.
+ *
+ * @param detector Root detector
+ * @returns Store enhancer
+ */
 export function createDetectorEnhancer<S>(detector: Detector<S>): StoreDetectableEnhancer<S> {
   if (typeof detector !== 'function') {
     throw new Error('Expected the detector to be a function.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export { Detector } from './Detector';
 export { StoreDetectable } from './StoreDetectable';
 
 // implementation
-export { combineDetectors } from './combineDetectors';
+export { reduceDetectors } from './reduceDetectors';
 export { createDetectorEnhancer } from './createDetectorEnhancer';
 export { createDetectableStore } from './createDetectableStore';
 export { mountDetector } from './mountDetector';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,11 @@
 export { Detector } from './Detector';
 export { DetectableStore } from './DetectableStore';
 
-// implementation
-export { reduceDetectors } from './reduceDetectors';
+// enhance redux store
 export { createDetectorEnhancer } from './createDetectorEnhancer';
 export { createDetectableStore } from './createDetectableStore';
+
+// reduce detectors
+export { reduceDetectors } from './reduceDetectors';
+export { combineDetectors } from './combineDetectors';
 export { mountDetector } from './mountDetector';

--- a/src/reduceDetectors.ts
+++ b/src/reduceDetectors.ts
@@ -1,7 +1,7 @@
 import { Detector } from './Detector';
 import { ActionLike } from './ActionLike';
 
-export function reduceDetectors<S, A>(...detectors: Detector<S>[]): Detector<S> {
+export function reduceDetectors<S>(...detectors: Detector<S>[]): Detector<S> {
   // check detectors types in runtime
   const invalidDetectorsIndexes: number[] = detectors
     .map((detector, index) => detector instanceof Function ? -1 : index)
@@ -15,8 +15,7 @@ export function reduceDetectors<S, A>(...detectors: Detector<S>[]): Detector<S> 
     );
   }
 
-  return function reducedDetector(prevState: S, nextState: S): A[] {
-  return function combinedDetector(prevState: S, nextState: S): ActionLike[] {
+  return function reducedDetector(prevState: S, nextState: S): ActionLike[] {
     return detectors
       .map(detector => detector(prevState, nextState) || [])
       .reduce<ActionLike[]>((actions: ActionLike[], nextActions: ActionLike | ActionLike[]) => actions.concat(nextActions), []);

--- a/src/reduceDetectors.ts
+++ b/src/reduceDetectors.ts
@@ -1,11 +1,6 @@
 import { Detector } from './Detector';
 
-export function combineDetectors<S, A>(detectors: Detector<S>[]): Detector<S> {
-  // check detectors array type in runtime
-  if (!!detectors && Array !== detectors.constructor) {
-    throw new Error(`First argument in combineDetectors function should be an 'array' type, '${typeof detectors}' type passed.`);
-  }
-
+export function reduceDetectors<S, A>(...detectors: Detector<S>[]): Detector<S> {
   // check detectors types in runtime
   const invalidDetectorsIndexes: number[] = detectors
     .map((detector, index) => detector instanceof Function ? -1 : index)
@@ -13,13 +8,13 @@ export function combineDetectors<S, A>(detectors: Detector<S>[]): Detector<S> {
 
   if (invalidDetectorsIndexes.length) {
     throw new Error(
-      `First argument in combineDetectors function has invalid values at indexes ${invalidDetectorsIndexes.join(', ')}.\n` +
+      `Invalid ${invalidDetectorsIndexes.join(', ')} arguments in reduceDetectors function.\n` +
       `Detectors should be a 'function' type, ` +
       `'${invalidDetectorsIndexes.map(index => typeof detectors[index]).join(`', '`)}' types passed.`
     );
   }
 
-  return function combinedDetector(prevState: S, nextState: S): A[] {
+  return function reducedDetector(prevState: S, nextState: S): A[] {
     return detectors
       .map(detector => detector(prevState, nextState) || [])
       .reduce<A[]>((actions: A[], nextActions: A[]) => actions.concat(nextActions), []);

--- a/test/combineDetectors.spec.ts
+++ b/test/combineDetectors.spec.ts
@@ -1,0 +1,103 @@
+
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import { assert, expect } from 'chai';
+import { Detector, combineDetectors } from '../src/index';
+
+chai.use(spies);
+
+describe('combineDetectors', function () {
+  it('should export reduceDetectors function', function () {
+    assert.isFunction(combineDetectors);
+  });
+
+  it('should return valid detector for empty map', function () {
+    const detector = combineDetectors({});
+
+    assert.isFunction(detector);
+    assert.deepEqual([], detector({}, {}));
+    assert.deepEqual([], detector(undefined, {}));
+  });
+
+  it('should return detector that binds detectors to local state', function () {
+    const aDetector = chai.spy();
+    const bDetector = chai.spy();
+    const detector = combineDetectors({
+      a: aDetector,
+      b: bDetector
+    });
+
+    const prevState = {
+      a: 'foo',
+      b: 'bar'
+    };
+    const nextState = {
+      a: 123,
+      b: 321
+    };
+
+    assert.isFunction(detector);
+    assert.deepEqual([], detector(prevState, nextState));
+    expect(aDetector).to.have.been.called.once.with('foo', 123);
+    expect(bDetector).to.have.been.called.once.with('bar', 321);
+  });
+
+  it('should merge actions returned by combined detectors', function () {
+    function detectorA(prevState, nextState) {
+      if (prevState === 'a' && nextState === 'b') {
+        return [{ type: 'A_TO_B_TRANSITION' }];
+      }
+    }
+    function detectorB(prevState, nextState) {
+      if (prevState !== nextState && (prevState === 'a' || prevState === 'b')) {
+        return { type: 'FROM_A_OR_B_TRANSITION' };
+      }
+    }
+    function detectorC(prevState, nextState) {
+      return undefined;
+    }
+
+    const detector: Detector<any> = combineDetectors({
+      a: detectorA,
+      b: detectorB,
+      c: detectorC
+    });
+
+    assert.deepEqual([], detector({}, {}));
+    assert.deepEqual([], detector(undefined, {}));
+    assert.deepEqual(
+      [
+        { type: 'A_TO_B_TRANSITION' },
+        { type: 'FROM_A_OR_B_TRANSITION' }
+      ],
+      detector(
+        {
+          a: 'a',
+          b: 'a'
+        },
+        {
+          a: 'b',
+          b: 'b',
+          c: 'c'
+        }
+      )
+    );
+    assert.deepEqual(
+      [
+        { type: 'FROM_A_OR_B_TRANSITION' },
+      ],
+      detector(
+        {
+          a: 'b',
+          b: 'b',
+          c: 'a'
+        },
+        {
+          a: 'c',
+          b: 'd',
+          c: 'b'
+        }
+      )
+    );
+  });
+});

--- a/test/reduceDetectors.spec.ts
+++ b/test/reduceDetectors.spec.ts
@@ -3,11 +3,11 @@ import { assert } from 'chai';
 import { reduceDetectors } from '../src/index';
 
 describe('reduceDetectors', function () {
-  it('check if redux-detector exports reduceDetectors', function () {
+  it('should export reduceDetectors function', function () {
     assert.isFunction(reduceDetectors);
   });
 
-  it('check if reduction of two detectors returns valid detector', function () {
+  it('should return valid detector for reduction of two detectors', function () {
     function detectorA() {
       return [{type: 'ACTION_A'}, {type: 'ACTION_B'}];
     }
@@ -26,7 +26,7 @@ describe('reduceDetectors', function () {
     assert.deepEqual(detectorAB({}, {}), [{type: 'ACTION_A'}, {type: 'ACTION_B'}, {type: 'ACTION_C'}]);
   });
 
-  it('check if reduction of two detectors passes states in valid order', function () {
+  it('should pass states in valid order for reduction of two detectors', function () {
     function detectorA(prevState, nextState) {
       if (prevState > nextState) {
         return [{type: 'PREV_STATE_GREATER'}];
@@ -49,7 +49,7 @@ describe('reduceDetectors', function () {
     assert.deepEqual(detectorAB(30, 20), [{type: 'PREV_STATE_GREATER'}]);
   });
 
-  it('check if it can reduce detectors with undefined result on no-action detect', function () {
+  it('should allow to reduce detectors with undefined result on no-action detect', function () {
     function detectorA(prevState, nextState) {
       if (prevState > nextState) {
         return [{type: 'PREV_STATE_GREATER'}];
@@ -68,7 +68,7 @@ describe('reduceDetectors', function () {
     assert.deepEqual(detectorAB(30, 20), [{type: 'PREV_STATE_GREATER'}]);
   });
 
-  it('should allow to combine detectors with array and single result', () => {
+  it('should allow to reduce detectors with array and single result', () => {
     function detectorA() {
       return [{type: 'ARRAY_DETECTOR'}];
     }
@@ -77,22 +77,19 @@ describe('reduceDetectors', function () {
       return {type: 'SINGLE_DETECTOR'};
     }
 
-    const detectorAB = combineDetectors(detectorA, detectorB);
+    const detectorAB = reduceDetectors(detectorA, detectorB);
 
     assert.deepEqual(detectorAB(undefined, undefined), [{type: 'ARRAY_DETECTOR'}, {type: 'SINGLE_DETECTOR'}]);
   });
 
-  it('should throw an exception for call with invalid argument', () => {
-    assert.throws(() => { (combineDetectors as any)({ 'foo': 'bar' }); }, Error);
-    assert.throws(() => { (combineDetectors as any)([function() {}, undefined]); }, Error);
-  it('check if it can return valid reduced detector for empty arguments', function() {
+  it('should return valid reduced detector for empty arguments', function() {
     const emptyDetector = reduceDetectors();
 
     assert.isFunction(emptyDetector);
     assert.deepEqual(emptyDetector(10, 20), []);
   });
 
-  it('check if invalid argument call will throw an exception', function () {
+  it('should throw an exception for invalid arguments', function () {
     assert.throws(function () { (reduceDetectors as any)({ 'foo': 'bar' }); }, Error);
     assert.throws(function () { (reduceDetectors as any)(function() {}, undefined); }, Error);
   });

--- a/test/reduceDetectors.spec.ts
+++ b/test/reduceDetectors.spec.ts
@@ -1,13 +1,13 @@
 
 import { assert } from 'chai';
-import { combineDetectors } from '../src/index';
+import { reduceDetectors } from '../src/index';
 
-describe('combineDetectors', function () {
-  it('check if redux-detector exports combineDetectors', function () {
-    assert.isFunction(combineDetectors);
+describe('reduceDetectors', function () {
+  it('check if redux-detector exports reduceDetectors', function () {
+    assert.isFunction(reduceDetectors);
   });
 
-  it('check if combination of two detectors returns valid detector', function () {
+  it('check if reduction of two detectors returns valid detector', function () {
     function detectorA() {
       return [{type: 'ACTION_A'}, {type: 'ACTION_B'}];
     }
@@ -16,7 +16,7 @@ describe('combineDetectors', function () {
       return [{type: 'ACTION_C'}];
     }
 
-    const detectorAB = combineDetectors([detectorA, detectorB]);
+    const detectorAB = reduceDetectors(detectorA, detectorB);
 
     assert.isFunction(detectorAB);
     assert.isArray(detectorAB({}, {}));
@@ -26,7 +26,7 @@ describe('combineDetectors', function () {
     assert.deepEqual(detectorAB({}, {}), [{type: 'ACTION_A'}, {type: 'ACTION_B'}, {type: 'ACTION_C'}]);
   });
 
-  it('check if combination of two detectors passes states in valid order', function () {
+  it('check if reduction of two detectors passes states in valid order', function () {
     function detectorA(prevState, nextState) {
       if (prevState > nextState) {
         return ['PREV_STATE'];
@@ -43,13 +43,13 @@ describe('combineDetectors', function () {
       return [];
     }
 
-    const detectorAB = combineDetectors([detectorA, detectorB]);
+    const detectorAB = reduceDetectors(detectorA, detectorB);
 
     assert.deepEqual(detectorAB(-10, 50), ['NEXT_STATE']);
     assert.deepEqual(detectorAB(30, 20), ['PREV_STATE']);
   });
 
-  it('check if it can combine detectors with undefined result on no-action detect', function () {
+  it('check if it can reduce detectors with undefined result on no-action detect', function () {
     function detectorA(prevState, nextState) {
       if (prevState > nextState) {
         return ['PREV_STATE'];
@@ -62,16 +62,21 @@ describe('combineDetectors', function () {
       }
     }
 
-    const detectorAB = combineDetectors([detectorA, detectorB]);
+    const detectorAB = reduceDetectors(detectorA, detectorB);
 
     assert.deepEqual(detectorAB(-10, 50), ['NEXT_STATE']);
     assert.deepEqual(detectorAB(30, 20), ['PREV_STATE']);
+  });
+
+  it('check if it can return valid reduced detector for empty arguments', function() {
+    const emptyDetector = reduceDetectors();
+
+    assert.isFunction(emptyDetector);
+    assert.deepEqual(emptyDetector(10, 20), []);
   });
 
   it('check if invalid argument call will throw an exception', function () {
-    assert.throws(function () { (combineDetectors as any)(); }, Error);
-    assert.throws(function () { (combineDetectors as any)({ 'foo': 'bar' }); }, Error);
-    assert.throws(function () { (combineDetectors as any)(function () {}, function () {}); }, Error);
-    assert.throws(function () { (combineDetectors as any)([function() {}, undefined]); }, Error);
+    assert.throws(function () { (reduceDetectors as any)({ 'foo': 'bar' }); }, Error);
+    assert.throws(function () { (reduceDetectors as any)(function() {}, undefined); }, Error);
   });
 });


### PR DESCRIPTION
## THIS IS BREAKING CHANGE ##
Thanks to other project that use `redux-detector`, i've found that instead of one `combineDetectors` we should have `reduceDetectors` (previous combine) and `combineDetectors` similar to `combineReducers` from `redux`.
With this two functions we are able to reuse small detectors and it's more readable and easier than using `mountDetector` function.