### PR TITLE
feat: 🎸 Make action type less strict

### DIFF
--- a/src/Detector.ts
+++ b/src/Detector.ts
@@ -1,5 +1,3 @@
-import { Action, AnyAction } from "redux";
-
 /**
  * Function that reduces previous and next state to single value.
  */
@@ -11,10 +9,10 @@ export type Detector<TState = any, TResult = any> = (
 /**
  * Function that compares previous and next state and can return action, array of actions or nothing.
  */
-export type ActionsDetector<
-  TState = any,
-  TAction extends Action = AnyAction
-> = Detector<TState, TAction | TAction[] | void>;
+export type ActionsDetector<TState = any, TAction = any> = Detector<
+  TState,
+  TAction | TAction[] | void
+>;
 
 /**
  * Function that compares previous and next state and returns boolean value

--- a/src/combineDetectors.ts
+++ b/src/combineDetectors.ts
@@ -1,10 +1,8 @@
-import { Action, AnyAction } from "redux";
 import { ActionsDetector } from "./Detector";
 
-type ActionsDetectorsMap<
-  TState extends object,
-  TAction extends Action = AnyAction
-> = { [K in keyof TState]?: ActionsDetector<TState[K], TAction> };
+type ActionsDetectorsMap<TState extends object, TAction = any> = {
+  [K in keyof TState]?: ActionsDetector<TState[K], TAction>
+};
 
 /**
  * Combine detectors to bind them to the local state.
@@ -13,10 +11,9 @@ type ActionsDetectorsMap<
  * @param map Map of detectors bounded to state.
  * @returns Combined detector
  */
-export function combineDetectors<
-  TState extends object,
-  TAction extends Action = AnyAction
->(map: ActionsDetectorsMap<TState, TAction>): ActionsDetector<TState, TAction> {
+export function combineDetectors<TState extends object, TAction = any>(
+  map: ActionsDetectorsMap<TState, TAction>
+): ActionsDetector<TState, TAction> {
   return function combinedDetector(
     prevState?: TState,
     nextState?: TState

--- a/src/composeDetectors.ts
+++ b/src/composeDetectors.ts
@@ -1,10 +1,9 @@
-import { Action, AnyAction } from "redux";
 import { ActionsDetector } from "./Detector";
 
 /**
  * Compose many action detectors into one detector that aggregates actions returned by given detectors
  */
-export function composeDetectors<TState, TAction extends Action = AnyAction>(
+export function composeDetectors<TState = any, TAction = any>(
   ...detectors: ActionsDetector<TState, TAction>[]
 ): ActionsDetector<TState, TAction> {
   // check detectors types in runtime
@@ -25,8 +24,8 @@ export function composeDetectors<TState, TAction extends Action = AnyAction>(
   }
 
   return function composedDetector(
-    prevState: TState | undefined,
-    nextState: TState | undefined
+    prevState?: TState,
+    nextState?: TState
   ): any[] {
     return detectors
       .map(detector => detector(prevState, nextState) || [])

--- a/src/conditionDetector.ts
+++ b/src/conditionDetector.ts
@@ -1,17 +1,10 @@
-import { Action, AnyAction } from "redux";
 import { ActionsDetector, ConditionDetector } from "./Detector";
 
-export function conditionDetector<
-  TState = any,
-  TAction extends Action = AnyAction
->(
+export function conditionDetector<TState = any, TAction = any>(
   condition: ConditionDetector<TState>,
   actions: ActionsDetector<TState, TAction>
 ): ActionsDetector<TState, TAction> {
-  return function conditionalDetector(
-    prevState: TState | undefined,
-    nextState: TState | undefined
-  ) {
+  return function conditionalDetector(prevState?: TState, nextState?: TState) {
     if (condition(prevState, nextState)) {
       return actions(prevState, nextState);
     }

--- a/src/mapDetector.ts
+++ b/src/mapDetector.ts
@@ -8,12 +8,12 @@ export function mapDetector<
   TInnerState = any,
   TResult = any
 >(
-  selector: (state: TOuterState | undefined) => TInnerState,
+  selector: (state?: TOuterState) => TInnerState,
   detector: Detector<TInnerState, TResult>
 ): Detector<TOuterState, TResult> {
   return function mappedDetector(
-    prevState: TOuterState | undefined,
-    nextState: TOuterState | undefined
+    prevState?: TOuterState,
+    nextState?: TOuterState
   ): TResult {
     return detector(selector(prevState), selector(nextState));
   };


### PR DESCRIPTION
In order to be compatible with redux middlewares like redux-thunk, the
default `TAction` type has been changed to any (it was `TAction extends
AnyAction = AnyAction`).